### PR TITLE
Allow non utf-8 requests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-	"plugins": ["transform-es2015-parameters"]
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: node_js
 node_js:
-- '4.3'
 - '6'
+- '8'
+- '10'
+- '11'
 cache:
   directories:
   - node_modules

--- a/README.md
+++ b/README.md
@@ -83,6 +83,33 @@ get({
 })
 ```
 
+#### Character encoding
+
+By default responses are handled as UTF-8, if you're dealing with other types of encodings you can specify the value in the request object
+
+```js
+import { get } from 'simple-get-promise';
+
+get({
+	url: 'http://example.com',
+	encoding: 'latin1',
+});
+```
+
+Node.js supports only a [handful of encodings](https://github.com/nodejs/node/blob/master/lib/buffer.js), if the one you needed is not available you can set `encoding: false` and handle the response directly as binary.
+
+```js
+import { get } from 'simple-get-promise';
+import iconv from 'iconv-lite';
+
+const { buffer } = await get({
+	url: 'http://example.com',
+	encoding: false,
+});
+console.log(iconv.decode(buffer, 'Shift_JIS'));
+```
+
+
 ### JSON
 
 Extract the message and signature from the cookie.

--- a/package.json
+++ b/package.json
@@ -14,22 +14,20 @@
   ],
   "scripts": {
     "prebuild": "eslint src test",
-    "build": "rollup -c rollup.config.cjs.js && rollup -c rollup.config.es6.js",
+    "build": "rollup -c rollup.config.js",
     "pretest": "rollup -c rollup.config.test.js",
     "test": "tap tmp/test-bundle.js",
     "prepublish": "npm test && npm run build",
     "watch": "nodemon --watch src --watch test --exec \"npm test\""
   },
   "devDependencies": {
-    "babel-plugin-transform-es2015-parameters": "^6.11.3",
-    "eslint": "^3.0.1",
-    "rollup": "^0.34.1",
-    "rollup-plugin-babel": "^2.6.1",
-    "rollup-plugin-multi-entry": "^2.0.0",
-    "tap": "^6.1.1"
+    "eslint": "^5.12.0",
+    "rollup": "^1.0.2",
+    "rollup-plugin-multi-entry": "^2.1.0",
+    "tap": "^12.1.1"
   },
   "engines": {
-    "node": ">= 4.3"
+    "node": ">= 6"
   },
   "bugs": {
     "url": "https://github.com/piuccio/simple-get-promise/issues"

--- a/rollup.base.config.js
+++ b/rollup.base.config.js
@@ -1,6 +1,0 @@
-import babel from 'rollup-plugin-babel';
-
-export default {
-	entry: 'src/index.js',
-	plugins: [babel()]
-};

--- a/rollup.config.cjs.js
+++ b/rollup.config.cjs.js
@@ -1,8 +1,0 @@
-import base from './rollup.base.config';
-
-const config = Object.assign({
-	format: 'cjs',
-	dest: 'dist/get.cjs.js'
-}, base);
-
-export default config;

--- a/rollup.config.es6.js
+++ b/rollup.config.es6.js
@@ -1,8 +1,0 @@
-import base from './rollup.base.config';
-
-const config = Object.assign({
-	format: 'es',
-	dest: 'dist/get.es6.js'
-}, base);
-
-export default config;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,11 @@
+module.exports = {
+  input: 'src/index.js',
+  output: [{
+    file: 'dist/get.cjs.js',
+    format: 'cjs',
+  }, {
+    file: 'dist/get.esm.js',
+    format: 'esm'
+  }],
+  external: ['http', 'https', 'url'],
+};

--- a/rollup.config.test.js
+++ b/rollup.config.test.js
@@ -1,10 +1,11 @@
-import babel from 'rollup-plugin-babel';
 import multiEntry from 'rollup-plugin-multi-entry';
 
 export default {
-	entry: 'test/**/*.test.js',
-	plugins: [babel(), multiEntry()],
-	format: 'cjs',
-	dest: 'tmp/test-bundle.js',
-	sourceMap: true
+	input: 'test/**/*.test.js',
+	plugins: [multiEntry()],
+	output: [{
+		file: 'tmp/test-bundle.js',
+		format: 'cjs',
+		sourceMap: true,
+	}],
 };

--- a/test/get.test.js
+++ b/test/get.test.js
@@ -45,7 +45,7 @@ tap.test('Fails if the response is not 200', test => {
 });
 
 tap.test('Returns response and response text correctly', test => {
-	test.plan(2);
+	test.plan(3);
 
 	const mock = {
 		request (request, cb) {
@@ -61,5 +61,6 @@ tap.test('Returns response and response text correctly', test => {
 	.then(res => {
 		test.equal(res.statusCode, 200);
 		test.equal(res.responseText, 'my response');
+		test.equal(res.buffer.toString(), 'my response');
 	});
 });

--- a/test/lib/emitters.js
+++ b/test/lib/emitters.js
@@ -17,7 +17,7 @@ export class EmitterNotFound extends BaseEmitter {
 		super();
 		this.statusCode = 404;
 		process.nextTick(() => {
-			this.emit('data', 'Not Found');
+			this.emit('data', Buffer.from('Not Found'));
 			this.emit('end');
 		});
 	}
@@ -27,7 +27,7 @@ export class EmitterTextResponse extends BaseEmitter {
 		super();
 		this.statusCode = 200;
 		process.nextTick(() => {
-			this.emit('data', text);
+			this.emit('data', Buffer.from(text));
 			this.emit('end');
 		});
 	}
@@ -38,8 +38,8 @@ export class EmitterJsonResponse extends BaseEmitter {
 		this.statusCode = 200;
 		process.nextTick(() => {
 			const response = JSON.stringify(json);
-			this.emit('data', response.slice(0, 2));
-			this.emit('data', response.slice(2));
+			this.emit('data', Buffer.from(response.slice(0, 2)));
+			this.emit('data', Buffer.from(response.slice(2)));
 			this.emit('end');
 		});
 	}


### PR DESCRIPTION
It's now possible to set the encoding of a request or `false` to disable 
any encoding.

Also update dependencies and drop support for node 4