### PR TITLE
Add loading comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 Simple modern way to make http requests. Supports HTTPS, ES6, JSON and Promises.
 
+### Loading
+
+```js
+// CommonJS
+const { get } = require('simple-get-promise');
+
+// ES Module
+import { get } from 'simple-get-promise';
+```
+
 ### Simple GET
 
 ```js


### PR DESCRIPTION
At first I made a mistake and got an error.

```js
const get = require('simple-get-promise');
// TypeError: get is not a function
```

I think it's polite if there is also a CommonJS method.

And, the content quoted node-fetch.

- [node\-fetch/node\-fetch: A light\-weight module that brings Fetch API to Node\.js](https://github.com/node-fetch/node-fetch)
