### PR TITLE
Update ES module field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "version": "3.0.0",
   "license": "Apache-2.0",
   "main": "dist/get.cjs.js",
-  "jsnext:main": "dist/get.es6.js",
+  "module": "dist/get.esm.js",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
Rollup's outputting to https://github.com/piuccio/simple-get-promise/blob/60bf34297ce626ac568b2f485bc92051df668f31/rollup.config.js#L7

Additionally rename `jsnext:main` to the now defacto `module` field.